### PR TITLE
Add mechanism for providing db overrides.

### DIFF
--- a/.github/scripts/make_db.py
+++ b/.github/scripts/make_db.py
@@ -25,8 +25,12 @@ def GenerateId():
 
 
 def main(unused_argv):
+  # Create directory for output database if it does not already exist.
+  pathlib.Path(OUTPUT_DB).parent.mkdir(parents=True, exist_ok=True)
+
   with pathlib.Path(OUTPUT_DB).open('w', encoding='UTF-8') as macros_db:
     for filename in pathlib.Path(SOURCE_PATH).glob('*.js'):
+      # Apply entry defaults.
       entry = {}
       entry['_id'] = GenerateId()
       entry['name'] = filename.with_suffix('').name.replace('_', ' ')
@@ -41,6 +45,15 @@ def main(unused_argv):
       entry['permission']['default'] = 0
       entry['permission'][AUTHOR_ID] = 3
       entry['flags'] = {}
+
+      # Parse and apply entry overrides from header.
+      for line in filename.open().readlines():
+        if line.startswith('//'):
+          key, value = line.split(':')
+          entry[key.lstrip('//').strip()] = value.strip()
+        else:
+          break
+
       json.dump(entry, macros_db)
       macros_db.write('\n')
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Playing around with foundry macros.
 
 ## Release Process
 
-To create a release, after commiting to the main branch, create and push a
+To create a release, after committing to the main branch, create and push a
 release tag with the version and description, e.g.
 
 ```
@@ -12,3 +12,9 @@ git tag -a v0.0.4 -m "Move script to database."
 git push --tags
 
 ```
+
+## Script Entry Overrides
+
+Default database tags may be overridden with colon-separated key-value pairs
+at the beginning of the script.  See `scripts/Twilight_Sanctuary.js` for an
+example of this functionality.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "foundryVTTmacros",
   "title": "Foundry VTT macros.",
   "description": "Playing around with foundry macros.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Mike Godwin <godzig@gmail.com>",
   "minimumCoreVersion": "0.8.6",
   "compatibleCoreVersion": "9",

--- a/scripts/Twilight_Sanctuary.js
+++ b/scripts/Twilight_Sanctuary.js
@@ -1,3 +1,5 @@
+// name: Twilight Sanctuary
+// img: icons/svg/dice-target.svg
 async function tempHP({
     actor
 }) {


### PR DESCRIPTION
Default script database entries may be overridden by using colon-separated key-value pairs in the header of the script.